### PR TITLE
Bump strip-ansi dep to 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/timoxley/columnify",
   "dependencies": {
-    "strip-ansi": "^0.2.1",
+    "strip-ansi": "^1.0.0",
     "wcwidth.js": "~0.0.4"
   },
   "directories": {


### PR DESCRIPTION
In the near future, `^0.x.y` will only allow exactly the `0.x.y` version, in
accordance with the specification at http://semver.org

The `strip-ansi` package has recently updated to 1.0.0, with no significant
API change, so we should be using that instead now.
