### PR TITLE
Updating the README to describe option usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,6 @@ console.log(columns)
 Objects are converted to a list of key/value pairs:
 
 ```javascript
-
 var data = {
   "commander@0.6.1": 1,
   "minimatch@0.2.14": 3,
@@ -100,65 +99,6 @@ mod1    0.0.1
 module2 0.2.0  
 ```
 
-
-### Setting Global and Per Column Options
-
-
-### Maximum and Minimum Column Widths
-You can define the `maxWidth` and `minWidth` globally, or for specified columns. By default wrapping will happen at word boundaries. Empty cells or those which do not fill the `maxWidth`/`minWidth` will be padded with spaces.
-
-```javascript
-
-var columns = columnify([{
-  name: 'mod1',
-  description: 'some description which happens to be far larger than the max',
-  version: '0.0.1',
-}, {
-  name: 'module-two',
-  description: 'another description larger than the max',
-  version: '0.2.0',
-}], {
-  minWidth: 20, // all columns have a minWidth of 20 chars
-  config: {description: {maxWidth: 30}} // the description has a maxWidth of 30 chars
-});
-
-console.log(columns);
-```
-
-#### Output:
-```
-NAME                 DESCRIPTION                    VERSION             
-mod1                 some description which happens 0.0.1               
-                     to be far larger than the max                      
-module-two           another description larger     0.2.0               
-                     than the max                         
-```
-
-#### Truncating Column Cells Instead of Wrapping
-
-You can disable wrapping and instead truncate content at the maximum
-column width. Truncation respects word boundaries.  A truncation marker,
-`…` will appear next to the last word in any truncated line.
-
-```javascript
-var columns = columnify(data, {
-  truncate: true,
-  config: {
-    description: {
-      maxWidth: 20
-    }
-  }
-})
-
-console.log(columns)
-```
-#### Output:
-```
-NAME       DESCRIPTION          VERSION
-mod1       some description…    0.0.1  
-module-two another description… 0.2.0  
-```
-
 ### Filtering & Ordering Columns
 
 By default, all properties are converted into columns, whether or not
@@ -192,10 +132,80 @@ module1 0.0.1
 module2 0.2.0
 ```
 
+## Global and Per Column Options
+You can set a number of options at a global level (ie. for all columns) or on a per column basis.
 
-## Other Configuration Options
+Set options on a per column basis by using the `config` option to specify individual columns. (See examples below).
+
+```javascript
+var columns = columnify(data, {
+  optionName: optionValue,
+  config: {
+    columnName: {optionName: optionValue},
+    columnName: {optionName: optionValue},
+  }
+});
+```
+
+### Maximum and Minimum Column Widths
+You can define the `maxWidth` and `minWidth` globally, or for specified columns. By default wrapping will happen at word boundaries. Empty cells or those which do not fill the `maxWidth`/`minWidth` will be padded with spaces.
+
+```javascript
+var columns = columnify([{
+  name: 'mod1',
+  description: 'some description which happens to be far larger than the max',
+  version: '0.0.1',
+}, {
+  name: 'module-two',
+  description: 'another description larger than the max',
+  version: '0.2.0',
+}], {
+  minWidth: 20, // all columns have a minWidth of 20 chars
+  config: {
+    description: {maxWidth: 30} // the description has a maxWidth of 30 chars
+  } 
+});
+
+console.log(columns);
+```
+
+#### Output:
+```
+NAME                 DESCRIPTION                    VERSION             
+mod1                 some description which happens 0.0.1               
+                     to be far larger than the max                      
+module-two           another description larger     0.2.0               
+                     than the max                         
+```
+
+#### Truncating Column Cells Instead of Wrapping
+
+You can disable wrapping and instead truncate content at the maximum
+column width by using the `truncate` option. Truncation respects word boundaries.  A truncation marker,
+`…` will appear next to the last word in any truncated line.
+
+```javascript
+var columns = columnify(data, {
+  truncate: true,
+  config: {
+    description: {
+      maxWidth: 20
+    }
+  }
+})
+
+console.log(columns)
+```
+#### Output:
+```
+NAME       DESCRIPTION          VERSION
+mod1       some description…    0.0.1  
+module-two another description… 0.2.0  
+```
+
 
 ### Align Right/Center
+You can set the alignment of the column data by using the `align` option.
 
 ```js
 var data = {
@@ -215,10 +225,12 @@ commander@2.0.0          1
 debug@0.8.1              1
 ```
 
-Align Center works in a similar way.
+`align: 'center'` works in a similar way.
 
 
-### Padding
+### Padding Character
+
+Set a character to fill whitespace within columns with the `paddingChr` option.
 
 ```js
 var data = {
@@ -288,7 +300,7 @@ runforcover@0.0.2 node_modules/tap/node_modules/runforcover
 ### Custom Truncation Marker
 
 You can change the truncation marker to something other than the default
-`…`.
+`…` by using the `truncateMarker` option.
 
 ```javascript
 var columns = columnify(data, {
@@ -313,10 +325,9 @@ module-two another description> 0.2.0
 ### Custom Column Splitter
 
 If your columns need some bling, you can split columns with custom
-characters.
+characters by using the `columnSplitter` option.
 
 ```javascript
-
 var columns = columnify(data, {
   columnSplitter: ' | '
 })
@@ -332,36 +343,33 @@ module-two | another description larger than the max                      | 0.2.
 
 ### Do not show headers
 
-Prevent columns headers from showing with:
+Control whether column header are displayed by using the `showHeaders` option.
 
 ```javascript
-
 var columns = columnify(data, {
   showHeaders: false
 })
 ```
 
 ## Transforming Column Data and Headers
-If you need to modify the presentation of column content or heading content there are two useful options for doing that: `dataTransform` and `headerTransform`. Both of these take a function and must return a string.
+If you need to modify the presentation of column content or heading content there are two useful options for doing that: `dataTransform` and `headerTransform`. Both of these take a function and need to return a valid string.
 
 ```javascript
 var columns = columnify([{
     name: 'mod1',
-    description: 'some description which happens to be far larger than the max'
+    description: 'SOME DESCRIPTION TEXT.'
 }, {
     name: 'module-two',
-    description: 'another description larger than the max'
+    description: 'SOME SLIGHTLY LONGER DESCRIPTION TEXT.'
 }], {
-    headingTransform: function(heading) {
-        return heading.charAt(0).toUpperCase() + heading.substring(1).toLowerCase();
-    },
     dataTransform: function(data) {
-        return data + " \u001b[32m(see description)\u001b[39m"; // adds Green text to the end of the data
+        return data.toLowerCase();
     },
     config: {
         name: {
-            dataTransform: function(data) {
-                return data.toUpperCase(); // overrides global dataTransform
+            headingTransform: function(heading) {
+              heading = "module " + heading;
+              return "\u001b[32m" +  heading.toUpperCase() + "\u001b[39m";// green header
             }
         }
     }
@@ -369,9 +377,9 @@ var columns = columnify([{
 ```
 #### Output:
 ```
-Name       Description                                                                   
-MOD1       some description which happens to be far larger than the max (see description)
-MODULE-TWO another description larger than the max (see description)   
+MODULE NAME DESCRIPTION                           
+mod1        some description text.                
+module-two  some slightly longer description text.
 ```
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -340,9 +340,9 @@ mod1       | some description which happens to be far larger than the max | 0.0.
 module-two | another description larger than the max                      | 0.2.0
 ```
 
-### Do not show headers
+### Control Header Display
 
-Control whether column header are displayed by using the `showHeaders` option.
+Control whether column headers are displayed by using the `showHeaders` option.
 
 ```javascript
 var columns = columnify(data, {

--- a/Readme.md
+++ b/Readme.md
@@ -160,9 +160,9 @@ var columns = columnify([{
   description: 'another description larger than the max',
   version: '0.2.0',
 }], {
-  minWidth: 20, // all columns have a minWidth of 20 chars
+  minWidth: 20,
   config: {
-    description: {maxWidth: 30} // the description has a maxWidth of 30 chars
+    description: {maxWidth: 30}
   } 
 })
 

--- a/Readme.md
+++ b/Readme.md
@@ -100,12 +100,12 @@ mod1    0.0.1
 module2 0.2.0  
 ```
 
-### Wrapping Column Cells
 
-You can define the maximum width before wrapping for individual cells in
-columns. Minimum width is also supported. Wrapping will happen at word
-boundaries. Empty cells or those which do not fill the max/min width
-will be padded with spaces.
+### Setting Global and Per Column Options
+
+
+### Maximum and Minimum Column Widths
+You can define the `maxWidth` and `minWidth` globally, or for specified columns. By default wrapping will happen at word boundaries. Empty cells or those which do not fill the `maxWidth`/`minWidth` will be padded with spaces.
 
 ```javascript
 
@@ -117,20 +117,24 @@ var columns = columnify([{
   name: 'module-two',
   description: 'another description larger than the max',
   version: '0.2.0',
-})
+}], {
+  minWidth: 20, // all columns have a minWidth of 20 chars
+  config: {description: {maxWidth: 30}} // the description has a maxWidth of 30 chars
+});
 
-console.log(columns)
+console.log(columns);
 ```
+
 #### Output:
 ```
-NAME       DESCRIPTION                    VERSION
-mod1       some description which happens 0.0.1
-           to be far larger than the max
-module-two another description larger     0.2.0
-           than the max
+NAME                 DESCRIPTION                    VERSION             
+mod1                 some description which happens 0.0.1               
+                     to be far larger than the max                      
+module-two           another description larger     0.2.0               
+                     than the max                         
 ```
 
-### Truncating Column Cells
+#### Truncating Column Cells Instead of Wrapping
 
 You can disable wrapping and instead truncate content at the maximum
 column width. Truncation respects word boundaries.  A truncation marker,
@@ -232,7 +236,7 @@ shortKey................... veryVeryVeryVeryVeryLongVal
 veryVeryVeryVeryVeryLongKey shortVal...................
 ```
 
-### Preserve existing newlines
+### Preserve Existing Newlines
 
 By default, `columnify` sanitises text by replacing any occurance of 1 or more whitespace characters with a single space.
 
@@ -336,6 +340,40 @@ var columns = columnify(data, {
   showHeaders: false
 })
 ```
+
+## Transforming Column Data and Headers
+If you need to modify the presentation of column content or heading content there are two useful options for doing that: `dataTransform` and `headerTransform`. Both of these take a function and must return a string.
+
+```javascript
+var columns = columnify([{
+    name: 'mod1',
+    description: 'some description which happens to be far larger than the max'
+}, {
+    name: 'module-two',
+    description: 'another description larger than the max'
+}], {
+    headingTransform: function(heading) {
+        return heading.charAt(0).toUpperCase() + heading.substring(1).toLowerCase();
+    },
+    dataTransform: function(data) {
+        return data + " \u001b[32m(see description)\u001b[39m"; // adds Green text to the end of the data
+    },
+    config: {
+        name: {
+            dataTransform: function(data) {
+                return data.toUpperCase(); // overrides global dataTransform
+            }
+        }
+    }
+});
+```
+#### Output:
+```
+Name       Description                                                                   
+MOD1       some description which happens to be far larger than the max (see description)
+MODULE-TWO another description larger than the max (see description)   
+```
+
 
 ## Multibyte Character Support
 

--- a/Readme.md
+++ b/Readme.md
@@ -350,7 +350,7 @@ var columns = columnify(data, {
 })
 ```
 
-## Transforming Column Data and Headers
+### Transforming Column Data and Headers
 If you need to modify the presentation of column content or heading content there are two useful options for doing that: `dataTransform` and `headerTransform`. Both of these take a function and need to return a valid string.
 
 ```javascript

--- a/Readme.md
+++ b/Readme.md
@@ -148,7 +148,7 @@ var columns = columnify(data, {
 ```
 
 ### Maximum and Minimum Column Widths
-You can define the `maxWidth` and `minWidth` globally, or for specified columns. By default wrapping will happen at word boundaries. Empty cells or those which do not fill the `maxWidth`/`minWidth` will be padded with spaces.
+As with all options, you can define the `maxWidth` and `minWidth` globally, or for specified columns. By default, wrapping will happen at word boundaries. Empty cells or those which do not fill the `minWidth` will be padded with spaces.
 
 ```javascript
 var columns = columnify([{
@@ -181,8 +181,7 @@ module-two           another description larger     0.2.0
 #### Truncating Column Cells Instead of Wrapping
 
 You can disable wrapping and instead truncate content at the maximum
-column width by using the `truncate` option. Truncation respects word boundaries.  A truncation marker,
-`…` will appear next to the last word in any truncated line.
+column width by using the `truncate` option. Truncation respects word boundaries.  A truncation marker, `…`, will appear next to the last word in any truncated line.
 
 ```javascript
 var columns = columnify(data, {

--- a/Readme.md
+++ b/Readme.md
@@ -119,7 +119,7 @@ var data = [{
 }]
 
 var columns = columnify(data, {
-  columns: ['name', 'version'] // note description not included
+  columns: ['name', 'version']
 })
 
 console.log(columns)
@@ -135,7 +135,7 @@ module2 0.2.0
 ## Global and Per Column Options
 You can set a number of options at a global level (ie. for all columns) or on a per column basis.
 
-Set options on a per column basis by using the `config` option to specify individual columns. (See examples below).
+Set options on a per column basis by using the `config` option to specify individual columns:
 
 ```javascript
 var columns = columnify(data, {
@@ -144,7 +144,7 @@ var columns = columnify(data, {
     columnName: {optionName: optionValue},
     columnName: {optionName: optionValue},
   }
-});
+})
 ```
 
 ### Maximum and Minimum Column Widths
@@ -164,9 +164,9 @@ var columns = columnify([{
   config: {
     description: {maxWidth: 30} // the description has a maxWidth of 30 chars
   } 
-});
+})
 
-console.log(columns);
+console.log(columns)
 ```
 
 #### Output:
@@ -362,23 +362,23 @@ var columns = columnify([{
     description: 'SOME SLIGHTLY LONGER DESCRIPTION TEXT.'
 }], {
     dataTransform: function(data) {
-        return data.toLowerCase();
+        return data.toLowerCase()
     },
     config: {
         name: {
             headingTransform: function(heading) {
-              heading = "module " + heading;
-              return "\u001b[32m" +  heading.toUpperCase() + "\u001b[39m";// green header
+              heading = "module " + heading
+              return "*" +  heading.toUpperCase() + "*"
             }
         }
     }
-});
+})
 ```
 #### Output:
 ```
-MODULE NAME DESCRIPTION                           
-mod1        some description text.                
-module-two  some slightly longer description text.
+*MODULE NAME* DESCRIPTION                           
+mod1          some description text.                
+module-two    some slightly longer description text.
 ```
 
 


### PR DESCRIPTION
For: https://github.com/timoxley/columnify/issues/18

I updated the README to include max/minWidth, dataTransform and headingTransform.
I think the format of the README was quite verbs to start with but I kept the existing format.

Also added a section to describe global vs per column settings.

Hope this helps!