### PR TITLE
Add support for hiding individual column headers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -369,6 +369,15 @@ var columns = columnify(data, {
 })
 ```
 
+This also works well for hiding a single column header, like an `id` column:
+```javascript
+var columns = columnify(data, {
+  config: {
+    id: { showHeaders: false }
+  }
+})
+```
+
 ### Transforming Column Data and Headers
 If you need to modify the presentation of column content or heading content there are two useful options for doing that: `dataTransform` and `headerTransform`. Both of these take a function and need to return a valid string.
 

--- a/index.js
+++ b/index.js
@@ -118,6 +118,12 @@ module.exports = function(items, options = {}) {
   if(options.showHeaders) {
     columnNames.forEach(columnName => {
       let column = columns[columnName]
+
+      if(!column.showHeaders){
+        headers[columnName] = '';
+        return;
+      }
+
       headers[columnName] = column.headingTransform(column.name)
     })
     items.unshift(headers)

--- a/test/hide-individual-header-expected.txt
+++ b/test/hide-individual-header-expected.txt
@@ -1,0 +1,3 @@
+  NAME    VERSION
+0 module1 0.0.1  
+1 module2 0.2.0  

--- a/test/hide-individual-header.js
+++ b/test/hide-individual-header.js
@@ -1,0 +1,20 @@
+var test = require('tape')
+var fs = require('fs')
+
+var columnify =  require('../')
+
+var data = [{
+  id: 0,
+  name: 'module1',
+  version: '0.0.1'
+}, {
+  id: 1,
+  name: 'module2',
+  version: '0.2.0'
+}]
+
+test('hide id column', function(t) {
+  t.plan(1)
+  var expected = fs.readFileSync(__dirname + '/hide-individual-header-expected.txt', 'utf8')
+  t.equal(columnify(data, {config: {id: {showHeaders: false}} }), expected)
+})


### PR DESCRIPTION
Adding on to #16

----

Since the "Control Header Display" section was under "Global and Per Column Options" I thought it would be neat to make it possible to hide just a single column header like so:

```js
var columns = columnify(data, {
  config: {
    columnName: {showHeaders: false},
  }
})
```

Quite neat to hide for example first column headers like "ID" etc.