### PR TITLE
Use SVG badge for Travis status

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 [![NPM](https://nodei.co/npm/columnify.png?downloads=true&downloadRank=true&stars=true&chrome)](https://nodei.co/npm-dl/columnify/)
 [![NPM](https://nodei.co/npm-dl/columnify.png?months=3&height=3&chrome)](https://nodei.co/npm/columnify/)
 
-[![Build Status](https://travis-ci.org/timoxley/columnify.png?branch=master)](https://travis-ci.org/timoxley/columnify)
+[![Build Status](https://img.shields.io/travis/timoxley/columnify.svg?style=flat)](https://travis-ci.org/timoxley/columnify)
 [![NPM Version](https://img.shields.io/npm/v/columnify.svg?style=flat)](https://npmjs.org/package/columnify)
 [![License](http://img.shields.io/npm/l/columnify.svg?style=flat)](LICENSE)
 [![Dependency Status](https://david-dm.org/timoxley/columnify.svg)](https://david-dm.org/timoxley/columnify)


### PR DESCRIPTION
The Travis-CI `.png` badge looked a too different from the rest.

If you want to specify a branch like before it can be done with: `https://img.shields.io/travis/timoxley/columnify/master.svg?style=flat`
The badge defaults to `master`.


before | after
--------- | ------
![](https://travis-ci.org/timoxley/columnify.png?branch=master) | ![](https://img.shields.io/travis/timoxley/columnify.svg?style=flat)