### PR TITLE
Added column name to data transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ module.exports = function(items, options = {}) {
     let column = columns[columnName]
     items = items.map((item, index) => {
       let col = Object.create(column)
-      item[columnName] = column.dataTransform(item[columnName], col, index)
+      item[columnName] = column.dataTransform(item[columnName], col, index, columnName)
 
       let changedKeys = Object.keys(col)
       // disable default heading transform if we wrote to column.name

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "columnify",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Render data in text columns. Supports in-column text-wrap.",
   "main": "columnify.js",
   "scripts": {


### PR DESCRIPTION
Example may want to make the data "columnName: dataValue" limited right now as the column name is not a parameter in dataTransform function

Example below

```javascript
var columns = columnify([
    {
        columnOne: 'testing',
        columnTwo: 'testing2'
    }
], {
    columnSplitter: ' | ',
    showHeaders: false,
    columns: ['columnOne', 'columnTwo'],
    dataTransform: function(data, col, index, columnName) {
        return columnName+': '+data
    }
})
```