### PR TITLE
fix: update strip-ansi to v6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/timoxley/columnify",
   "dependencies": {
-    "strip-ansi": "^3.0.0",
+    "strip-ansi": "^6.0.1",
     "wcwidth": "^1.0.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "url": "https://github.com/timoxley/columnify/issues"
   },
   "homepage": "https://github.com/timoxley/columnify",
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "dependencies": {
     "strip-ansi": "^6.0.1",
     "wcwidth": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "columnify",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "Render data in text columns. Supports in-column text-wrap.",
   "main": "columnify.js",
   "scripts": {


### PR DESCRIPTION
- fixes #61
- requires at least node v8 https://github.com/chalk/strip-ansi/releases/tag/v6.0.0